### PR TITLE
Added client/server specific memcached connection counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ traffic statistics for each key seen.  It currently reports on the following met
 * **req/sec** - the number of requests per second for the key
 * **bw (kbps)** - the estimated netowrk bandwidth consumed by this key in kilobits-per-second
 
+Optional metrics:
+  When used with the -c or --detailed-calls flag
+  * **server calls** - the number of times the key has been requested from the local memcached server since mctop started
+  * **client calls** - the number of times the key has been requested from this server to an external memcached server since mctop started
+
+
 ## Getting it running
 
 the quickest way to get it running is to:
@@ -42,6 +48,7 @@ the quickest way to get it running is to:
         -p, --port=PORT                  Network port to sniff on (default 11211)
         -d, --discard=THRESH             Discard keys with request/sec rate below THRESH
         -r, --refresh=MS                 Refresh the stats display every MS milliseconds
+        -c, --detailed-calls             Detailed client/server call stats
         -h, --help                       Show usage info
 
 ## User interface commands
@@ -49,6 +56,8 @@ the quickest way to get it running is to:
 The following key commands are available in the console UI:
 
 * `C` - sort by number of calls
+* `E` - sort by number of server calls
+* `L` - sort by number of client calls
 * `S` - sort by object size
 * `R` - sort by requests/sec
 * `B` - sort by bandwidth

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ the quickest way to get it running is to:
         -d, --discard=THRESH             Discard keys with request/sec rate below THRESH
         -r, --refresh=MS                 Refresh the stats display every MS milliseconds
         -c, --detailed-calls             Detailed client/server call stats
+        -a, --ip-address=1.1.1.1         IP address of memcached instance (used for client/server stats)
         -h, --help                       Show usage info
 
 ## User interface commands

--- a/bin/mctop
+++ b/bin/mctop
@@ -46,6 +46,10 @@ until done do
             done = true
         when /[Cc]/
             sort_mode = :calls
+        when /[Ee]/
+            sort_mode = :server_calls
+        when /[Ll]/
+            sort_mode = :client_calls
         when /[Ss]/
             sort_mode = :objsize
         when /[Rr]/

--- a/bin/mctop
+++ b/bin/mctop
@@ -47,9 +47,13 @@ until done do
         when /[Cc]/
             sort_mode = :calls
         when /[Ee]/
-            sort_mode = :server_calls
+            if @config[:detailed_calls]
+                sort_mode = :server_calls
+            end
         when /[Ll]/
-            sort_mode = :client_calls
+            if @config[:detailed_calls]
+                sort_mode = :client_calls
+            end
         when /[Ss]/
             sort_mode = :objsize
         when /[Rr]/

--- a/lib/cmdline.rb
+++ b/lib/cmdline.rb
@@ -1,5 +1,6 @@
 require 'optparse'
 require 'pcap'
+require 'socket'
 
 class CmdLine
     def self.parse(args)
@@ -16,18 +17,23 @@ class CmdLine
             end
 
             @config[:discard_thresh] = 0
-            opt.on '-d', '--discard=THRESH', Float, 'Discard keys with request/sec rate below THRESH' do |discard_thresh|
+            opt.on('-d', '--discard=THRESH', Float, 'Discard keys with request/sec rate below THRESH') do |discard_thresh|
                 @config[:discard_thresh] = discard_thresh
             end
 
             @config[:refresh_rate] = 500
-            opt.on '-r', '--refresh=MS', Float, 'Refresh the stats display every MS milliseconds' do |refresh_rate|
+            opt.on('-r', '--refresh=MS', Float, 'Refresh the stats display every MS milliseconds') do |refresh_rate|
                 @config[:refresh_rate] = refresh_rate
             end
 
             @config[:detailed_calls] = false
-            opt.on '-c', '--detailed-calls', 'Detailed client/server call stats' do |detailed_calls|
+            opt.on('-c', '--detailed-calls', 'Detailed client/server call stats') do |detailed_calls|
                 @config[:detailed_calls] = true
+            end
+
+            @config[:ip_address] = IPSocket.getaddress(Socket.gethostname)
+            opt.on('-a', '--ip-address=1.1.1.1', 'IP address of memcached instance (used for client/server stats)') do |ip_address|
+                @config[:ip_address] = ip_address
             end
 
             opt.on_tail '-h', '--help', 'Show usage info' do

--- a/lib/cmdline.rb
+++ b/lib/cmdline.rb
@@ -25,6 +25,11 @@ class CmdLine
                 @config[:refresh_rate] = refresh_rate
             end
 
+            @config[:detailed_calls] = false
+            opt.on '-c', '--detailed-calls', 'Detailed client/server call stats' do |detailed_calls|
+                @config[:detailed_calls] = true
+            end
+
             opt.on_tail '-h', '--help', 'Show usage info' do
                 puts opts
                 exit

--- a/lib/sniffer.rb
+++ b/lib/sniffer.rb
@@ -1,17 +1,15 @@
 require 'pcap'
 require 'thread'
-require 'socket'
 
 class MemcacheSniffer
     attr_accessor :metrics, :semaphore
 
     def initialize(config)
-        @source    = config[:nic]
-        @port      = config[:port]
+        @source         = config[:nic]
+        @port           = config[:port]
         @detailed_calls = config[:detailed_calls]
+        @ip             = config[:ip_address]
 
-        # uses default interface, figure out how to get the specific interface's ip
-	@ip	   = IPSocket.getaddress(Socket.gethostname)
 
         @metrics = {}
         @metrics[:calls]          = {}

--- a/lib/ui.rb
+++ b/lib/ui.rb
@@ -20,8 +20,8 @@ class UI
             init_pair(2, COLOR_WHITE, COLOR_RED)
         end
 
-        @stat_cols      = %w[ calls objsize req/sec bw(kbps) ]
-        @stat_col_width = 10 
+        @stat_cols      = %w[ calls server client objsize req/sec bw(kbps) ]
+        @stat_col_width = 10
         @key_col_width  = 0
 
         @commands = {
@@ -124,11 +124,21 @@ class UI
                 else
                     display_key = k
                 end
+
+                if sniffer.metrics[:server_calls][k].nil?
+                  sniffer.metrics[:server_calls][k] = 0
+                end
+
+                if sniffer.metrics[:client_calls][k].nil?
+                  sniffer.metrics[:client_calls][k] = 0
+                end
            
                 # render each key
-                line = sprintf "%-#{@key_col_width}s %9.d %9.d %9.2f %9.2f",
+                line = sprintf "%-#{@key_col_width}s %9.d %9.d %9.d %9.d %9.2f %9.2f",
                                  display_key,
                                  sniffer.metrics[:calls][k],
+                                 sniffer.metrics[:server_calls][k],
+                                 sniffer.metrics[:client_calls][k],
                                  sniffer.metrics[:objsize][k],
                                  sniffer.metrics[:reqsec][k],
                                  sniffer.metrics[:bw][k]

--- a/lib/ui.rb
+++ b/lib/ui.rb
@@ -27,6 +27,8 @@ class UI
         @commands = {
             'Q' => "quit",
             'C' => "sort by calls",
+            'E' => "sort by server calls",
+            'L' => "sort by client calls",
             'S' => "sort by size",
             'R' => "sort by req/sec",
             'B' => "sort by bandwidth",

--- a/lib/ui.rb
+++ b/lib/ui.rb
@@ -20,20 +20,33 @@ class UI
             init_pair(2, COLOR_WHITE, COLOR_RED)
         end
 
-        @stat_cols      = %w[ calls server client objsize req/sec bw(kbps) ]
+        if @config[:detailed_calls]
+            @stat_cols = %w[ calls server client objsize req/sec bw(kbps) ]
+        else
+            @stat_cols = %w[ calls objsize req/sec bw(kbps) ]
+        end
+
         @stat_col_width = 10
         @key_col_width  = 0
 
         @commands = {
             'Q' => "quit",
-            'C' => "sort by calls",
-            'E' => "sort by server calls",
-            'L' => "sort by client calls",
+            'C' => "sort by calls"
+        }
+
+        if @config[:detailed_calls]
+            @commands.merge!({
+                'E' => "sort by server calls",
+                'L' => "sort by client calls"
+            })
+        end
+
+        @commands.merge!({
             'S' => "sort by size",
             'R' => "sort by req/sec",
             'B' => "sort by bandwidth",
             'T' => "toggle sort order (asc|desc)"
-        }
+        })
     end
 
     def header
@@ -127,19 +140,30 @@ class UI
                     display_key = k
                 end
 
-                # Set default values for these if they're not currently set
-                sniffer.metrics[:server_calls][k] = 0 if sniffer.metrics[:server_calls][k].nil?
-                sniffer.metrics[:client_calls][k] = 0 if sniffer.metrics[:client_calls][k].nil?
+                if @config[:detailed_calls]
+                    # Set default values for these if they're not currently set
+                    sniffer.metrics[:server_calls][k] = 0 if sniffer.metrics[:server_calls][k].nil?
+                    sniffer.metrics[:client_calls][k] = 0 if sniffer.metrics[:client_calls][k].nil?
            
-                # render each key
-                line = sprintf "%-#{@key_col_width}s %9.d %9.d %9.d %9.d %9.2f %9.2f",
-                                 display_key,
-                                 sniffer.metrics[:calls][k],
-                                 sniffer.metrics[:server_calls][k],
-                                 sniffer.metrics[:client_calls][k],
-                                 sniffer.metrics[:objsize][k],
-                                 sniffer.metrics[:reqsec][k],
-                                 sniffer.metrics[:bw][k]
+                    # render each key
+                    line = sprintf "%-#{@key_col_width}s %9.d %9.d %9.d %9.d %9.2f %9.2f",
+                                     display_key,
+                                     sniffer.metrics[:calls][k],
+                                     sniffer.metrics[:server_calls][k],
+                                     sniffer.metrics[:client_calls][k],
+                                     sniffer.metrics[:objsize][k],
+                                     sniffer.metrics[:reqsec][k],
+                                     sniffer.metrics[:bw][k]
+                else
+                    # render each key
+                    line = sprintf "%-#{@key_col_width}s %9.d %9.d %9.2f %9.2f",
+                                     display_key,
+                                     sniffer.metrics[:calls][k],
+                                     sniffer.metrics[:objsize][k],
+                                     sniffer.metrics[:reqsec][k],
+                                     sniffer.metrics[:bw][k]
+               end
+
             else
                 # we're not clearing the display between renders so erase past
                 # keys with blank lines if there's < maxlines of results

--- a/lib/ui.rb
+++ b/lib/ui.rb
@@ -127,13 +127,9 @@ class UI
                     display_key = k
                 end
 
-                if sniffer.metrics[:server_calls][k].nil?
-                  sniffer.metrics[:server_calls][k] = 0
-                end
-
-                if sniffer.metrics[:client_calls][k].nil?
-                  sniffer.metrics[:client_calls][k] = 0
-                end
+                # Set default values for these if they're not currently set
+                sniffer.metrics[:server_calls][k] = 0 if sniffer.metrics[:server_calls][k].nil?
+                sniffer.metrics[:client_calls][k] = 0 if sniffer.metrics[:client_calls][k].nil?
            
                 # render each key
                 line = sprintf "%-#{@key_col_width}s %9.d %9.d %9.d %9.d %9.2f %9.2f",


### PR DESCRIPTION
Currently, we run memcached on servers that serve to multiple machines, and also runs a local client software that makes queries outbound to local or other memcached servers. mctop does not differentiate between an incoming request to the memcached instance, or an outgoing request from the client.  I've added the optional flag -c or --detailed-calls which also provides a breakdown of the calls by client or server, enabled sorting of these columns, and added an option -i or --ip-address that allows the user to specify which ip memcached is listening on (by default it uses the local gateway ip address).

This has been very helpful to us in troubleshooting issues to make sure we're focusing on the proper keys, I thought it might be useful for others. I'm happy to make changes or adjustments if necessary.

Jason
