### PR TITLE
Add a --host option to look only at the traffic to a specific host

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ the quickest way to get it running is to:
     Usage: mctop [options]
         -i, --interface=NIC              Network interface to sniff (required)
         -p, --port=PORT                  Network port to sniff on (default 11211)
+            --host=HOST                  Network host to sniff on (default all)
         -d, --discard=THRESH             Discard keys with request/sec rate below THRESH
         -r, --refresh=MS                 Refresh the stats display every MS milliseconds
         -h, --help                       Show usage info

--- a/lib/cmdline.rb
+++ b/lib/cmdline.rb
@@ -10,6 +10,11 @@ class CmdLine
         @config[:nic] = nic
       end
 
+      @config[:host] = ''
+      opt.on('--host=HOST', 'Network host to sniff on (default all)') do |host|
+        @config[:host] = host
+      end
+
       @config[:port] = 11211
       opt.on('-p', '--port=PORT', 'Network port to sniff on (default 11211)') do |port|
         @config[:port] = port

--- a/lib/sniffer.rb
+++ b/lib/sniffer.rb
@@ -7,6 +7,7 @@ class MemcacheSniffer
   def initialize(config)
     @source  = config[:nic]
     @port    = config[:port]
+    @host    = config[:host]
 
     @metrics = {}
     @metrics[:calls]   = {}
@@ -25,7 +26,12 @@ class MemcacheSniffer
 
     @done    = false
 
-    cap.setfilter("port #{@port}")
+    if @host == ""
+      cap.setfilter("port #{@port}")
+    else
+      cap.setfilter("host #{@host} and port #{@port}")
+    end
+
     cap.loop do |packet|
       @metrics[:stats] = cap.stats
 


### PR DESCRIPTION
No short flag for that option, to avoid conflicting with --help.
