### PR TITLE
Setting exact dependency on ruby-pcap

### DIFF
--- a/mctop.gemspec
+++ b/mctop.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'ruby-pcap', '~> 0.7.8'
+  gem.add_runtime_dependency 'ruby-pcap', '= 0.7.8'
   gem.add_runtime_dependency 'curses', '~> 1.0.1'
 end


### PR DESCRIPTION
Version 0.7.9 doesn't seem to play well with mctop.  The code may
need to be refactored for the newer version, but 0.7.8 still works
like a champ.
